### PR TITLE
Enable api generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Documentation 🔎 (Sphinx and PyData)
+run-name: ${{ github.actor }} - Documentation 🔎 (Sphinx and PyData)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}-docs
+  cancel-in-progress: true
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install . --group docs
+
+      - name: Build Sphinx html documentation
+        run: |
+          sphinx-build -M html ./docs ./docs/_build
+
+      - name: Build Sphinx dirhtml documentation
+        run: |
+          sphinx-build -M dirhtml ./docs ./docs/_build
+
+      - name: Build Sphinx latex documentation
+        run: |
+          sphinx-build -M latex ./docs ./docs/_build
+
+      # Add commands to generate and process coverage reports using sphinx-reports or similar
+      - name: Sphinx Coverage
+        run: |
+          sphinx-build -M coverage ./docs ./docs/_build

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,4 +1,7 @@
 # Based on Python Semantic Release (PSR) and PYPI (Python Package Index) as of July-2025
+# This workflow automates the versioning and release process - automatically generating the -noop version output.
+# Requires a manual "workflow_dispatch" trigger from github Actions to actually deploy a release to PyPI.
+
 # [1] https://python-semantic-release.readthedocs.io/en/stable/configuration/automatic-releases/github-actions.html#examples
 # [2] https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
@@ -51,16 +54,20 @@ jobs:
         run: |
           echo "prerelease=${{ github.event.inputs.prerelease }}" >> $GITHUB_ENV
           echo "prerelease_token=${{ github.event.inputs.prerelease_token }}" >> $GITHUB_ENV
+          echo "dispatch=true" >> $GITHUB_ENV
       - name: Set default value for pre-release
         shell: bash
         if: ${{ github.event != 'workflow_dispatch' }}
         run: |
           echo "prerelease=true" >> $GITHUB_ENV
           echo "prerelease_token=beta" >> $GITHUB_ENV
-      - name: Display pre-release input
+          echo "dispatch=false" >> $GITHUB_ENV
+      - name: Display workflow, pre-release and token input
         shell: bash
         run: |
           echo "Python SemVer pre-release?: $prerelease"
+          echo "Python SemVer pre-release token: $prerelease_token"
+          echo "Python SemVer Workflow Dispatch: $dispatch"
       # Note: We checkout the repository at the branch that triggered the workflow
       # with the entire history to ensure to match PSR's release branch detection
       # and history evaluation.
@@ -135,7 +142,7 @@ jobs:
           prerelease_token: ${{ env.prerelease_token }}
           changelog: true
           verbosity: 2
-          no_operation_mode: ${{ github.repository_owner != 'xraysoftmat'}}
+          no_operation_mode: ${{ github.repository_owner != 'xraysoftmat' || env.dispatch == 'false' }}
 
       - name: Env | Check if released and log conditionals
         id: is_released
@@ -144,9 +151,11 @@ jobs:
           echo "Ownership: ${{ github.repository_owner }} ; ${{ github.repository_owner == 'xraysoftmat' }}"
           echo "Released: ${{ steps.release.outputs.released }}"
           echo "Branch: ${{ github.ref }}; ${{ github.ref == 'refs/heads/main' }}"
-          echo "released=${{ steps.release.outcome && github.ref == 'refs/heads/main' && steps.release.outputs.released && github.repository_owner == 'xraysoftmat' && steps.release.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+          echo "Dispatch (i.e. manual trigger): ${{ env.dispatch }}"
+          echo "released=${{ steps.release.outcome && (github.ref == 'refs/heads/main') && steps.release.outputs.released && (github.repository_owner == 'xraysoftmat') && (steps.release.outcome == 'success') && (env.dispatch == 'true') }}" >> "$GITHUB_OUTPUT"
 
       - name: Display | Release Information
+        # released exists, could be true/false.
         if: |
           success() && steps.is_released.outputs.released
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/_autosummary/
 
 # PyBuilder
 .pybuilder/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,9 @@ html_last_updated_fmt = "%b %d, %Y"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []  # ['_static']
+html_static_path = ["source/_static"]  # ['_static']
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["source/_templates"]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "project-templatedoc"
@@ -46,14 +48,12 @@ htmlhelp_basename = "project-templatedoc"
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-# for example.py
+# Insert the current docs directory
 sys.path.insert(0, os.path.abspath("."))
-# project root
-sys.path.insert(0, os.path.abspath(".."))
-# package root
-sys.path.insert(0, os.path.abspath("../pyNexafs/"))
-
-sys.path.insert(0, os.path.abspath("../../pyNexafs/"))
+# Insert the project root
+# sys.path.insert(0, os.path.abspath(".."))
+# Insert the package root
+sys.path.insert(0, "../pyNexafs/")
 
 os.environ["MPLBACKEND"] = "Agg"  # avoid tkinter import errors on rtfd.io
 
@@ -93,10 +93,9 @@ extensions = [
     "sphinx_copybutton",
     # "autoapi.extension",
     "matplotlib.sphinxext.plot_directive",
+    "sphinx.ext.coverage",
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["source/_templates"]
 
 # The root toctree document
 master_doc = "index"  # NOTE: will be changed to `root_doc` in sphinx 4
@@ -105,7 +104,7 @@ root_doc = master_doc
 # Setup the API auto-documentation
 autosummary_generate = True
 autosummary_generate_overwrite = True
-autosummary_imported_members = True
+# autosummary_imported_members = True
 autosummary_ignore_module_all = True
 
 # autoapi_dirs = ["../pyNexafs"]
@@ -142,9 +141,9 @@ latex_elements = {
 latex_documents = [
     (
         "index",
-        "numpydoc.tex",
-        "numpydoc Documentation",
-        "Numpydoc maintainers",
+        "pyNexafs.tex",
+        "pyNexafs Documentation",
+        "pyNexafs maintainers",
         "manual",
     ),
 ]

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,9 +5,16 @@ The API documentation for `pyNexafs` is generated from the docstrings in the cod
 It provides detailed information about the classes, methods, and functions available in the package.
 
 .. autosummary::
-   :toctree: ../_build/_autosummary
-   :template: custom-module-template.rst
+   :toctree: _autosummary
    :recursive:
 
-
    pyNexafs
+
+The submodules are
+
+.. autosummary::
+
+   pyNexafs.parsers
+   pyNexafs.nexafs
+   pyNexafs.gui
+   pyNexafs.utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ html_theme = "pydata_sphinx_theme"
 # Array item:
 [[tool.sphinx-pyproject.html_theme_options.icon_links]]
     name = "GitHub"
-    url = "https://github.com/numpy/numpydoc"
+    url = "https://github.com/xraysoftmat/pyNexafs"
     icon = "fab fa-github-square"
     type = "fontawesome"
 


### PR DESCRIPTION
Use autosummary sphinx extention to generate an API.
Generate a new build for documentation, including a coverage report [not integrated into tools like coveralls...]

Change releasing automation to only release on trigger.